### PR TITLE
[Tests] update from xenial to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-dist: xenial
+dist: focal
 addons:
   apt:
     packages:


### PR DESCRIPTION
"cosmic" is the oldest ubuntu distro node 18 supports, and travis-ci jumped straight from bionic to focal.